### PR TITLE
docs: remove unimplemented lkr doctor references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ Custom Keychain + Legacy ACL release. Pure FFI implementation (no CLI subprocess
 
 - `lkr init` — Create a dedicated `lkr.keychain-db` with password, auto-lock (5 min), lock-on-sleep
 - `lkr lock` — Explicitly lock the custom keychain
-- `lkr doctor` — Diagnose keychain health (existence, lock state, search list isolation, ACL status)
 - `lkr harden` — Re-apply Legacy ACL to all keys for the current binary path
 - Custom Keychain (`lkr.keychain-db`) — isolated from login.keychain, never added to search list (I1/SR9)
 - Legacy ACL (`SecAccessCreate` + `SecTrustedApplicationCreateFromPath`) — restricts key access to the LKR binary (Layer 2 defense)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -44,7 +44,6 @@ version changes Custom Keychain behavior (e.g., adding partition IDs to CSSM, de
 Custom Keychain creation APIs), Layer 2 (Authorization) could be weakened.
 
 **Mitigations**:
-- `lkr doctor` detects degradation (ACL not enforced, search list pollution)
 - `lkr harden` re-registers ACL, serving as a migration point if the mechanism changes
 - Layer 1 (Isolation via search list) is independent of ACL and provides baseline protection
 - The architecture is designed to be **migrated, not permanent** — if Apple provides a
@@ -171,7 +170,7 @@ not a gap waiting to be fixed.
 | IDE with pseudo-TTY (pty) bypasses TTY guard | Some IDEs allocate a pty; `isatty` returns true | TTY guard is defense-in-depth; use `lkr exec` as primary |
 | Child process logs env vars after `lkr exec` | LKR has no control over child behavior | Audit child programs; avoid untrusted commands |
 | Clipboard manager capturing copied keys | Third-party clipboard managers may persist history | 30s auto-clear mitigates; disable clipboard managers for sensitive use |
-| macOS deprecates Custom Keychain / CSSM format | Layer 2 (ACL) may stop working | `lkr doctor` detects; Layer 1 (isolation) is independent; see Platform Dependency Risk |
+| macOS deprecates Custom Keychain / CSSM format | Layer 2 (ACL) may stop working | Layer 1 (isolation) is independent; `lkr harden` serves as migration point; see Platform Dependency Risk |
 
 ### Keychain ACL Investigation (v0.2.1 — updated v0.3.0)
 


### PR DESCRIPTION
## Summary
- Remove `lkr doctor` from CHANGELOG.md (v0.3.0 Added section)
- Remove `lkr doctor` references from docs/SECURITY.md (2 locations)
- `lkr doctor` was documented but never implemented in code
- References replaced with `lkr harden` where appropriate
- `design-v030.md` retains doctor as future implementation target

## Context
Code review found that `lkr doctor` appears in release documentation but has no corresponding implementation in `lkr-cli` or `lkr-core`.

## Test plan
- [x] `grep -r doctor crates/` returns no matches (never implemented)
- [x] Documentation-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)