### PR TITLE
docs: add SAFETY comments to all unsafe blocks in lkr-core

### DIFF
--- a/crates/lkr-core/src/acl.rs
+++ b/crates/lkr-core/src/acl.rs
@@ -12,7 +12,9 @@ use security_framework::os::macos::keychain::SecKeychain;
 use std::ffi::{CString, c_void};
 use std::path::Path;
 
-// ── Hand-declared Security.framework symbols ────────────────────
+// Security.framework Legacy ACL symbols.
+// `SecTrustedApplicationCreateFromPath` and `SecAccessCreate` form the
+// only code-sign-free path to per-binary ACL on macOS Keychain.
 unsafe extern "C" {
     fn SecTrustedApplicationCreateFromPath(path: *const i8, app_out: *mut *mut c_void) -> i32;
 
@@ -25,7 +27,7 @@ unsafe extern "C" {
     fn SecKeychainItemCopyAccess(item_ref: *const c_void, access_out: *mut *mut c_void) -> i32;
 }
 
-// ── Core Foundation helpers ─────────────────────────────────────
+// CoreFoundation helpers for building the trusted application CFArray.
 unsafe extern "C" {
     fn CFArrayCreateMutable(
         allocator: *const c_void,
@@ -79,6 +81,11 @@ pub fn build_access(lkr_binary_path: &Path) -> Result<*mut c_void> {
     )
     .map_err(|e| Error::Acl(format!("Binary path contains NUL byte: {e}")))?;
 
+    // SAFETY: All FFI calls below use validated inputs:
+    // - path_cstr: validated to exist and be a regular file (SR5 checks above)
+    // - CF objects follow Create Rule: trusted_app, trusted_list, cf_desc,
+    //   access are all released before returning (or on error).
+    // - The returned access ptr follows Create Rule — caller must release.
     unsafe {
         // Step 1: Create a trusted application reference for the LKR binary
         let mut trusted_app: *mut c_void = std::ptr::null_mut();
@@ -140,6 +147,10 @@ pub unsafe fn is_acl_blocked(item_ref: *const c_void) -> bool {
 
     let _guard = SecKeychain::disable_user_interaction();
 
+    // SAFETY: item_ref is non-null (checked above) and is a valid
+    // SecKeychainItemRef provided by the caller (keymanager.rs).
+    // `access` follows Create Rule if returned; released immediately.
+    // disable_user_interaction guard prevents GUI dialogs.
     unsafe {
         let mut access: *mut c_void = std::ptr::null_mut();
         let status = SecKeychainItemCopyAccess(item_ref, &mut access);

--- a/crates/lkr-core/src/custom_keychain.rs
+++ b/crates/lkr-core/src/custom_keychain.rs
@@ -9,7 +9,9 @@ use security_framework::os::macos::keychain::{CreateOptions, SecKeychain};
 use std::ffi::c_void;
 use std::path::PathBuf;
 
-// ── Hand-declared Security.framework symbols ────────────────────
+// Security.framework Keychain lifecycle symbols.
+// These are not re-exported by the `security-framework` crate at the
+// level we need (lock/delete/search-list management).
 unsafe extern "C" {
     fn SecKeychainLock(keychain: *const c_void) -> i32;
     fn SecKeychainDelete(keychain: *const c_void) -> i32;
@@ -17,7 +19,8 @@ unsafe extern "C" {
     fn SecKeychainSetSearchList(search_list: *const c_void) -> i32;
 }
 
-// ── Core Foundation helpers ─────────────────────────────────────
+// CoreFoundation helpers for search list manipulation (CFArray iteration
+// and mutation).
 unsafe extern "C" {
     fn CFArrayGetCount(array: *const c_void) -> isize;
     fn CFArrayGetValueAtIndex(array: *const c_void, idx: isize) -> *const c_void;
@@ -110,6 +113,8 @@ pub fn unlock(keychain: &mut SecKeychain, password: &str) -> Result<()> {
 
 /// Lock the custom keychain.
 pub fn lock(keychain: &SecKeychain) -> Result<()> {
+    // SAFETY: keychain is a valid SecKeychainRef (from SecKeychain wrapper).
+    // as_concrete_TypeRef returns the inner CF pointer.
     let status = unsafe { SecKeychainLock(keychain.as_concrete_TypeRef() as _) };
     if status != 0 {
         return Err(Error::Keychain(format!(
@@ -121,6 +126,8 @@ pub fn lock(keychain: &SecKeychain) -> Result<()> {
 
 /// Delete the custom keychain (used by cleanup/reset).
 pub fn delete(keychain: &SecKeychain) -> Result<()> {
+    // SAFETY: keychain is a valid SecKeychainRef. SecKeychainDelete removes
+    // the keychain file and invalidates the ref. Caller must not use it after.
     let status = unsafe { SecKeychainDelete(keychain.as_concrete_TypeRef() as _) };
     if status != 0 {
         return Err(Error::Keychain(format!(
@@ -154,6 +161,13 @@ fn apply_settings(_keychain: &SecKeychain) -> Result<()> {
 ///
 /// Saves the original search list, filters out our keychain, and restores.
 pub fn ensure_not_in_search_list(keychain: &SecKeychain) -> Result<()> {
+    // SAFETY: Large unsafe block for search list manipulation.
+    // CF objects and their lifecycle:
+    // - search_list: Create Rule (from CopySearchList), released at end
+    // - new_list: Create Rule (from CFArrayCreateMutable), released after SetSearchList
+    // - verify_list: Create Rule (from CopySearchList), released after verification
+    // - Array element access: Get Rule (valid while parent array lives)
+    // keychain ref is borrowed (not consumed).
     unsafe {
         // Get current search list
         let mut search_list: *mut c_void = std::ptr::null_mut();
@@ -232,6 +246,9 @@ pub fn ensure_not_in_search_list(keychain: &SecKeychain) -> Result<()> {
 /// Check if the custom keychain is in the search list (for SR9 validation).
 /// Returns true if found (which is a violation of I1).
 pub fn is_in_search_list(keychain: &SecKeychain) -> Result<bool> {
+    // SAFETY: search_list follows Create Rule (from CopySearchList), released
+    // at end. Array elements are Get Rule (valid while search_list lives).
+    // keychain ref is borrowed (not consumed).
     unsafe {
         let mut search_list: *mut c_void = std::ptr::null_mut();
         let status = SecKeychainCopySearchList(&mut search_list);

--- a/crates/lkr-core/src/keymanager.rs
+++ b/crates/lkr-core/src/keymanager.rs
@@ -189,7 +189,8 @@ mod keychain_raw {
     };
     use security_framework_sys::keychain_item::{SecItemAdd, SecItemCopyMatching, SecItemDelete};
 
-    // CFDictionary raw operations — not exposed at the level we need by core_foundation
+    // CoreFoundation CFDictionary raw operations — not exposed at the level
+    // we need by the `core_foundation` crate.
     #[link(name = "CoreFoundation", kind = "framework")]
     unsafe extern "C" {
         fn CFDictionaryCreateMutable(
@@ -204,8 +205,8 @@ mod keychain_raw {
         static kCFTypeDictionaryValueCallBacks: c_void;
     }
 
-    // Accessibility constants from Security.framework.
-    // kSecAttrAccessible (key) may not be in security-framework-sys, so declare directly.
+    // Security.framework accessibility constants.
+    // Not all are re-exported by `security-framework-sys`, so we declare directly.
     #[link(name = "Security", kind = "framework")]
     unsafe extern "C" {
         static kSecAttrAccessible: *const c_void;
@@ -213,7 +214,9 @@ mod keychain_raw {
         static kSecMatchSearchList: *const c_void;
     }
 
-    // v0.3.0: Legacy Keychain API for CreateFromContent + FindGenericPassword
+    // Legacy Keychain C API (v0.3.0).
+    // `SecKeychainItemCreateFromContent` and `SecKeychainFindGenericPassword`
+    // are the only APIs that accept a `SecAccessRef` at creation time.
     unsafe extern "C" {
         fn SecKeychainItemCreateFromContent(
             item_class: u32,
@@ -256,6 +259,9 @@ mod keychain_raw {
     }
 
     fn new_dict() -> *mut c_void {
+        // SAFETY: CFDictionaryCreateMutable with NULL allocator uses the default
+        // allocator. The returned dict follows Create Rule (caller must release).
+        // kCFType*CallBacks are static, valid for program lifetime.
         unsafe {
             CFDictionaryCreateMutable(
                 ptr::null(),
@@ -271,6 +277,10 @@ mod keychain_raw {
     fn set_base(dict: *mut c_void, service: &str, account: &str) {
         let svc = CFString::new(service);
         let acct = CFString::new(account);
+        // SAFETY: `dict` is a valid mutable CFDictionary from new_dict().
+        // CFDictionarySetValue retains key/value refs (svc, acct stay valid
+        // through this scope; after SetValue the dict holds its own retain).
+        // kSec* constants are framework statics, valid for program lifetime.
         unsafe {
             CFDictionarySetValue(dict, kSecClass as _, kSecClassGenericPassword as _);
             CFDictionarySetValue(dict, kSecAttrService as _, svc.as_concrete_TypeRef() as _);
@@ -309,6 +319,9 @@ mod keychain_raw {
         let dict = new_dict();
         set_base(dict, service, account);
         let data = CFData::from_buffer(password);
+        // SAFETY: `dict` from new_dict() is valid. CFDictionarySetValue retains
+        // values. SecItemAdd reads the dict; dict is released after the call.
+        // All CF statics are valid for program lifetime.
         unsafe {
             CFDictionarySetValue(dict, kSecValueData as _, data.as_concrete_TypeRef() as _);
             // v0.2.0: Disable iCloud Keychain sync
@@ -335,6 +348,10 @@ mod keychain_raw {
     pub(super) fn get(service: &str, account: &str) -> Result<Vec<u8>> {
         let dict = new_dict();
         set_base(dict, service, account);
+        // SAFETY: `dict` from new_dict() is valid. SecItemCopyMatching reads
+        // the dict and writes a retained CF object into `result` (Create Rule).
+        // `result` is wrapped with wrap_under_create_rule to transfer ownership
+        // to Rust. Dict is released immediately after the query.
         unsafe {
             CFDictionarySetValue(
                 dict,
@@ -376,6 +393,8 @@ mod keychain_raw {
         set_base(query, service, account);
         let attrs = new_dict();
 
+        // SAFETY: `query` and `attrs` from new_dict() are valid. SecItemUpdate
+        // reads both dicts. Both are released after the call.
         unsafe {
             // Query: find item (SynchronizableAny for v0.1.0 compat)
             CFDictionarySetValue(
@@ -408,6 +427,8 @@ mod keychain_raw {
     pub(super) fn delete(service: &str, account: &str) -> Result<()> {
         let dict = new_dict();
         set_base(dict, service, account);
+        // SAFETY: `dict` from new_dict() is valid. SecItemDelete reads the dict
+        // and deletes matching items. Dict is released after the call.
         unsafe {
             // v0.1.0 keys may lack synchronizable attr; match all
             CFDictionarySetValue(
@@ -478,6 +499,10 @@ mod keychain_raw {
         let item_class: u32 = u32::from_be_bytes(*b"genp"); // kSecGenericPasswordItemClass
 
         let mut item_ref: *mut c_void = std::ptr::null_mut();
+        // SAFETY: All pointers are valid stack locals or CF refs held for the
+        // duration of the call. `keychain` and `access` are valid CF objects
+        // from the caller. `attr_list` points to stack-allocated attrs whose
+        // data pointers (svc_bytes, acct_bytes) remain valid through this scope.
         let status = unsafe {
             SecKeychainItemCreateFromContent(
                 item_class,
@@ -492,6 +517,8 @@ mod keychain_raw {
 
         // Release the item ref if returned (we don't need it)
         if !item_ref.is_null() {
+            // SAFETY: item_ref was returned by CreateFromContent (Create Rule),
+            // retain count == 1, released here.
             unsafe { CFRelease(item_ref as _) };
         }
 
@@ -524,6 +551,10 @@ mod keychain_raw {
         let mut pw_data: *mut c_void = std::ptr::null_mut();
         let mut item_ref: *mut c_void = std::ptr::null_mut();
 
+        // SAFETY: All byte slices (svc_bytes, acct_bytes) are valid for the
+        // call duration. Output pointers (pw_data, item_ref) are stack-local.
+        // Keychain ref is valid (held by caller). Returned pw_data follows
+        // Create Rule and must be freed with SecKeychainItemFreeContent.
         let status = unsafe {
             SecKeychainFindGenericPassword(
                 keychain.as_concrete_TypeRef() as _,
@@ -542,12 +573,16 @@ mod keychain_raw {
             if status == crate::error::os_status::ERR_SEC_INTERACTION_NOT_ALLOWED
                 && !item_ref.is_null()
             {
+                // SAFETY: item_ref is non-null (checked above), valid
+                // SecKeychainItemRef returned by FindGenericPassword.
                 let is_acl = unsafe { crate::acl::is_acl_blocked(item_ref as _) };
+                // SAFETY: item_ref follows Create Rule, released here.
                 unsafe { CFRelease(item_ref as _) };
                 if is_acl {
                     return Err(Error::AclMismatch);
                 }
             } else if !item_ref.is_null() {
+                // SAFETY: item_ref follows Create Rule, released on error path.
                 unsafe { CFRelease(item_ref as _) };
             }
             return Err(os_status_to_error(status, account));
@@ -555,6 +590,7 @@ mod keychain_raw {
 
         // Release the item ref (not needed for basic get)
         if !item_ref.is_null() {
+            // SAFETY: item_ref follows Create Rule, released on success path.
             unsafe { CFRelease(item_ref as _) };
         }
 
@@ -565,10 +601,14 @@ mod keychain_raw {
         }
 
         // Copy data out before freeing
+        // SAFETY: pw_data is non-null (checked above) and points to pw_length
+        // bytes allocated by Security.framework. Data is copied immediately
+        // into a Vec before freeing.
         let bytes = unsafe { std::slice::from_raw_parts(pw_data as *const u8, pw_length as usize) }
             .to_vec();
 
-        // Free the password data allocated by Security.framework
+        // SAFETY: pw_data was allocated by SecKeychainFindGenericPassword.
+        // SecKeychainItemFreeContent releases it. Must be called exactly once.
         unsafe {
             SecKeychainItemFreeContent(std::ptr::null(), pw_data);
         }
@@ -596,6 +636,8 @@ mod keychain_raw {
 
         let mut item_ref: *mut c_void = std::ptr::null_mut();
 
+        // SAFETY: Byte slices valid for call duration. pw_data/pw_length are
+        // null (not needed). item_ref is stack-local output pointer.
         let find_status = unsafe {
             SecKeychainFindGenericPassword(
                 keychain.as_concrete_TypeRef() as _,
@@ -619,7 +661,9 @@ mod keychain_raw {
             });
         }
 
+        // SAFETY: item_ref is non-null (checked above), valid SecKeychainItemRef.
         let delete_status = unsafe { SecKeychainItemDelete(item_ref) };
+        // SAFETY: item_ref follows Create Rule, released after delete.
         unsafe { CFRelease(item_ref as _) };
 
         if delete_status != 0 {
@@ -656,6 +700,7 @@ mod keychain_raw {
         let _guard = SecKeychain::disable_user_interaction()
             .map_err(|e| Error::Keychain(format!("Failed to disable user interaction: {e}")))?;
 
+        // Security.framework constants and functions for batch item enumeration.
         #[link(name = "Security", kind = "framework")]
         unsafe extern "C" {
             static kSecReturnAttributes: *const c_void;
@@ -672,7 +717,7 @@ mod keychain_raw {
             ) -> i32;
         }
 
-        // Build CFArray with single keychain for kSecMatchSearchList
+        // CoreFoundation CFArray helpers for building kSecMatchSearchList.
         unsafe extern "C" {
             fn CFArrayCreateMutable(
                 allocator: *const c_void,
@@ -686,6 +731,13 @@ mod keychain_raw {
         let dict = new_dict();
         let svc = CFString::new(service);
 
+        // SAFETY: Large unsafe block covering the entire batch-fetch lifecycle.
+        // `dict` from new_dict() is valid. All CF objects follow Create/Get Rule:
+        // - kc_array: Create Rule, released immediately after SecItemCopyMatching
+        // - dict: Create Rule, released immediately after SecItemCopyMatching
+        // - result: Create Rule (CFArray), released at end of function
+        // - item_dict entries: Get Rule (valid while result CFArray lives)
+        // - data_ptr from CopyContent: freed with SecKeychainItemFreeContent
         unsafe {
             CFDictionarySetValue(dict, kSecClass as _, kSecClassGenericPassword as _);
             CFDictionarySetValue(dict, kSecAttrService as _, svc.as_concrete_TypeRef() as _);
@@ -726,6 +778,7 @@ mod keychain_raw {
             }
 
             // Result is a CFArray of CFDictionaries (each with attrs + ref)
+            // CoreFoundation helpers for iterating the result CFArray.
             unsafe extern "C" {
                 fn CFArrayGetCount(array: *const c_void) -> isize;
                 fn CFArrayGetValueAtIndex(array: *const c_void, idx: isize) -> *const c_void;
@@ -842,8 +895,12 @@ impl KeychainStore {
     /// Extract the account name (kSecAttrAccount) from a CFDictionary.
     /// Returns None if the attribute is missing or not a valid string.
     fn extract_account(dict: &core_foundation::dictionary::CFDictionary) -> Option<String> {
+        // SAFETY: kSecAttrAccount is a framework static (Get Rule — no ownership
+        // transfer). wrap_under_get_rule is correct: we don't own the CFString.
         let account_key = unsafe { CFString::wrap_under_get_rule(kSecAttrAccount) };
         let account_ref = dict.find(account_key.as_CFTypeRef())?;
+        // SAFETY: account_ref is a CFString (Get Rule from dict.find).
+        // wrap_under_get_rule is correct: dict owns the value.
         let account = unsafe { CFString::wrap_under_get_rule(*account_ref as _) }.to_string();
         Some(account)
     }
@@ -975,6 +1032,8 @@ impl KeyStore for KeychainStore {
 
             // Release the access ref if we created one
             if !access.is_null() {
+                // SAFETY: access was returned by build_access() (Create Rule),
+                // retain count == 1. CFRelease is safe here.
                 unsafe {
                     unsafe extern "C" {
                         fn CFRelease(cf: *const c_void);

--- a/crates/lkr-core/src/lib.rs
+++ b/crates/lkr-core/src/lib.rs
@@ -1,3 +1,5 @@
+#![warn(clippy::undocumented_unsafe_blocks)]
+
 pub mod acl;
 pub mod custom_keychain;
 pub mod error;


### PR DESCRIPTION
## Summary
- Add `// SAFETY:` comments documenting pointer validity, CF ownership rules (Create/Get Rule), and retain count rationale for every `unsafe {}` block in lkr-core
- Add `//` comments to all `unsafe extern "C"` FFI declarations describing the source framework
- Enable `clippy::undocumented_unsafe_blocks` lint in `lib.rs` to enforce documentation on future unsafe blocks

## Files changed (4, comments only — zero code changes)
| File | Changes |
|------|---------|
| `keymanager.rs` | ~25 unsafe blocks + 5 extern decl comments |
| `acl.rs` | 2 unsafe blocks + 2 extern decl comments |
| `custom_keychain.rs` | 4 unsafe blocks + 2 extern decl comments |
| `lib.rs` | `#![warn(clippy::undocumented_unsafe_blocks)]` |

## Test plan
- [x] `cargo clippy -p lkr-core -- -D warnings` passes
- [x] `cargo test --workspace` — all 91 tests pass (70 unit + 8 integration + 13 CLI)
- [x] No code changes — comments and lint attribute only

🤖 Generated with [Claude Code](https://claude.com/claude-code)