### PR TITLE
chore: bump version to 0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.2] - 2026-03-13
+
+Operational quality release: bug fixes, code structure improvements, and documentation.
+
+### Fixed
+
+- `list` command N+1 query: fetched key values unnecessarily for each entry; now uses metadata-only query
+- `list` silently skipped keys when JSON deserialization failed; now returns an error
+
+### Changed
+
+- CLI refactored from single `main.rs` into per-command modules (`cmd/*.rs`) and `util.rs`
+- Added `// SAFETY:` comments to all `unsafe` blocks in `lkr-core`
+
+### Removed
+
+- Unimplemented `lkr doctor` references removed from CHANGELOG and SECURITY.md (deferred to v0.3.3)
+
 ## [0.3.1] - 2026-03-07
 
 Security hardening patch addressing code review feedback.
@@ -126,6 +144,7 @@ Initial release. Secure CLI for managing LLM API keys via macOS Keychain.
 - Generated files written with `0600` permissions
 - `.gitignore` coverage check on generated files
 
+[0.3.2]: https://github.com/yottayoshida/llm-key-ring/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/yottayoshida/llm-key-ring/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/yottayoshida/llm-key-ring/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/yottayoshida/llm-key-ring/compare/v0.2.0...v0.2.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lkr-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "arboard",
  "clap",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "lkr-core"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1283,9 +1283,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/lkr-core", "crates/lkr-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -345,8 +345,9 @@ remain readable via v0.2.x fallback until you manually remove them.
 |---------|-------|-------------|
 | v0.2.2 | Docs & Roadmap | Roadmap update, v0.3.0 upgrade guide preview |
 | **v0.3.0** | **Security: 3-Layer Defense** | Custom Keychain (`lkr.keychain-db`) + Legacy ACL via Pure FFI + cdhash. **Breaking change** — see below |
-| **v0.3.1** (current) | **Security Hardening** | ACL fail-closed, `keychain_path()` safety, `StoredEntry` zeroize-on-drop, `-25308` auto-diagnosis |
-| v0.3.2 | Operational Quality | Shell completions, Homebrew tap, `lkr config lock-timeout` |
+| **v0.3.1** | **Security Hardening** | ACL fail-closed, `keychain_path()` safety, `StoredEntry` zeroize-on-drop, `-25308` auto-diagnosis |
+| **v0.3.2** (current) | **Operational Quality** | List N+1 fix, CLI module split, unsafe SAFETY docs, Homebrew tap |
+| v0.3.3 | Diagnostics | `lkr doctor` (Keychain health check) |
 | v0.4.0 | MCP Server | IDE integration for secure key access |
 
 ## Development

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -354,8 +354,9 @@ enabling kind-based access control without separate metadata storage.
 |---------|---------------|
 | **v0.2.0** | Keychain attribute hardening + comprehensive TTY guard |
 | **v0.3.0** | Custom Keychain + Legacy ACL via Pure FFI (3-layer defense: isolation + cdhash authorization + binary integrity) |
-| **v0.3.1** (current) | Security hardening: ACL fail-closed, zeroize-on-drop, `-25308` auto-diagnosis |
-| v0.3.2 | Operational quality: shell completions, Homebrew tap, `lkr config lock-timeout` |
+| **v0.3.1** | Security hardening: ACL fail-closed, zeroize-on-drop, `-25308` auto-diagnosis |
+| **v0.3.2** (current) | Operational quality: list N+1 fix, CLI module split, Homebrew tap |
+| v0.3.3 | Diagnostics: `lkr doctor` (search list pollution, ACL/cdhash integrity check) |
 | v0.4.0 | MCP server with scoped access tokens |
 
 ## Reporting Security Issues


### PR DESCRIPTION
## Summary
- Cargo.toml workspace version `0.3.1` → `0.3.2`
- CHANGELOG: add v0.3.2 entry summarizing PR #6–#8 (list N+1 fix, CLI module split, unsafe SAFETY docs)
- README.md + SECURITY.md roadmap: mark v0.3.2 as current, add v0.3.3 for `lkr doctor` (deferred from this release)

## Scope decision
- `lkr doctor` deferred to v0.3.3 (large scope, Keychain test complexity, security team coordination needed)
- Homebrew tap will be set up after this PR merges (separate repo, not a version bump)

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo clippy --workspace -- -D warnings` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)