### PR TITLE
docs: add Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,19 @@ $ lkr gen .env.example -o .env       # Generate config from template
 ## Install
 
 ```bash
+# Homebrew (recommended)
+brew install yottayoshida/tap/lkr
+
 # From source
 git clone https://github.com/yottayoshida/llm-key-ring.git
 cd llm-key-ring
 cargo install --path crates/lkr-cli
 ```
 
-Requires Rust 1.85+ and macOS (uses native Keychain).
+Requires macOS (uses native Keychain). Source build requires Rust 1.85+.
+
+> **Note**: After upgrading (`brew upgrade lkr` or `cargo install --force`), run `lkr harden`
+> to refresh Keychain ACL for the new binary.
 
 ## Usage
 


### PR DESCRIPTION
## Summary
- Add `brew install yottayoshida/tap/lkr` as recommended install method
- Add note about `lkr harden` after upgrades

## Context
- Homebrew tap: https://github.com/yottayoshida/homebrew-tap
- Release: https://github.com/yottayoshida/llm-key-ring/releases/tag/v0.3.2
- `brew install` tested locally (v0.3.2, build-from-source)

## Test plan
- [x] Local `brew install yottayoshida/tap/lkr` works
- [x] `lkr --version` returns 0.3.2
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)