### PR TITLE
fix: resolve lkr migrate circular error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.3] - 2026-03-13
+
+### Fixed
+
+- **`lkr migrate` circular error**: `exists()` delegated to `get()`, which returns a "run `lkr migrate`" error for keys in login.keychain — causing migrate itself to fail on every key. Now `exists()` checks the custom keychain directly, bypassing legacy detection
+
 ## [0.3.2] - 2026-03-13
 
 Operational quality release: bug fixes, code structure improvements, and documentation.
@@ -144,6 +150,7 @@ Initial release. Secure CLI for managing LLM API keys via macOS Keychain.
 - Generated files written with `0600` permissions
 - `.gitignore` coverage check on generated files
 
+[0.3.3]: https://github.com/yottayoshida/llm-key-ring/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/yottayoshida/llm-key-ring/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/yottayoshida/llm-key-ring/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/yottayoshida/llm-key-ring/compare/v0.2.1...v0.3.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/lkr-core", "crates/lkr-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.2"
+version = "0.3.3"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -352,8 +352,9 @@ remain readable via v0.2.x fallback until you manually remove them.
 | v0.2.2 | Docs & Roadmap | Roadmap update, v0.3.0 upgrade guide preview |
 | **v0.3.0** | **Security: 3-Layer Defense** | Custom Keychain (`lkr.keychain-db`) + Legacy ACL via Pure FFI + cdhash. **Breaking change** — see below |
 | **v0.3.1** | **Security Hardening** | ACL fail-closed, `keychain_path()` safety, `StoredEntry` zeroize-on-drop, `-25308` auto-diagnosis |
-| **v0.3.2** (current) | **Operational Quality** | List N+1 fix, CLI module split, unsafe SAFETY docs, Homebrew tap |
-| v0.3.3 | Diagnostics | `lkr doctor` (Keychain health check) |
+| **v0.3.2** | **Operational Quality** | List N+1 fix, CLI module split, unsafe SAFETY docs, Homebrew tap |
+| **v0.3.3** (current) | **Bug Fix** | `lkr migrate` circular error fix |
+| v0.3.4 | Diagnostics | `lkr doctor` (Keychain health check) |
 | v0.4.0 | MCP Server | IDE integration for secure key access |
 
 ## Development

--- a/crates/lkr-core/src/keymanager.rs
+++ b/crates/lkr-core/src/keymanager.rs
@@ -1194,10 +1194,23 @@ impl KeyStore for KeychainStore {
     }
 
     fn exists(&self, name: &str) -> Result<bool> {
-        match self.get(name) {
-            Ok(_) => Ok(true),
-            Err(Error::KeyNotFound { .. }) => Ok(false),
-            Err(e) => Err(e),
+        if let Some(kc) = &self.custom_keychain {
+            // Check custom keychain directly, without legacy fallback.
+            // This avoids the circular error where get() returns a
+            // "run lkr migrate" message during migration itself.
+            match keychain_raw::get_v3(kc, &self.service, name) {
+                Ok(_) => Ok(true),
+                Err(Error::KeyNotFound { .. }) => Ok(false),
+                Err(Error::AclMismatch) => Ok(true), // key exists but ACL blocks read
+                Err(e) => Err(e),
+            }
+        } else {
+            // Legacy mode (no custom keychain)
+            match keychain_raw::get(&self.service, name) {
+                Ok(_) => Ok(true),
+                Err(Error::KeyNotFound { .. }) => Ok(false),
+                Err(e) => Err(e),
+            }
         }
     }
 }

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -355,8 +355,9 @@ enabling kind-based access control without separate metadata storage.
 | **v0.2.0** | Keychain attribute hardening + comprehensive TTY guard |
 | **v0.3.0** | Custom Keychain + Legacy ACL via Pure FFI (3-layer defense: isolation + cdhash authorization + binary integrity) |
 | **v0.3.1** | Security hardening: ACL fail-closed, zeroize-on-drop, `-25308` auto-diagnosis |
-| **v0.3.2** (current) | Operational quality: list N+1 fix, CLI module split, Homebrew tap |
-| v0.3.3 | Diagnostics: `lkr doctor` (search list pollution, ACL/cdhash integrity check) |
+| **v0.3.2** | Operational quality: list N+1 fix, CLI module split, Homebrew tap |
+| **v0.3.3** (current) | Bug fix: `lkr migrate` circular error |
+| v0.3.4 | Diagnostics: `lkr doctor` (search list pollution, ACL/cdhash integrity check) |
 | v0.4.0 | MCP server with scoped access tokens |
 
 ## Reporting Security Issues


### PR DESCRIPTION
## Summary
- `exists()` now checks the custom keychain directly via `keychain_raw::get_v3`, bypassing the legacy detection path in `get()`
- `AclMismatch` is treated as "key exists" (blocked by ACL but present)
- Version bump to v0.3.3

## Bug
`lkr migrate` failed on every key with: "Key 'X' found in login.keychain but not in lkr.keychain-db. Run `lkr migrate` to move your keys."

**Root cause**: `set()` → `exists()` → `get()` → legacy detection error. The `get()` method detects keys in login.keychain and returns a "run migrate" error, which `exists()` propagated, causing `migrate` itself to fail.

## Design alignment
- `get()` legacy detection (UX guidance) is preserved — `lkr get` still shows the migrate message
- `exists()` is now a pure existence check, not a migration advisor
- No security invariants (I1–I5) affected — change is in existence check logic only

## Test plan
- [x] `cargo test --workspace` — 8 passed, 2 ignored
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] CI passes
- [ ] Manual: `lkr migrate` successfully copies keys from login.keychain

🤖 Generated with [Claude Code](https://claude.com/claude-code)