### PR TITLE
fix(harden): resolve ACL chicken-and-egg after brew upgrade (#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.4] - 2026-03-14
+
+### Fixed
+
+- **`lkr harden` ACL chicken-and-egg**: after `brew upgrade`, the binary's cdhash changes and all keys become ACL-blocked. `harden` now uses interactive Keychain access (macOS authorization dialog) to read key values before re-creating them with a fresh ACL. Previously, `harden` tried non-interactive reads, which failed immediately on every key
+- **`-25293` misdiagnosed as wrong password**: `errSecAuthFailed` from `SecKeychainFindGenericPassword` is now checked for ACL cdhash mismatch (same as `-25308`), returning `AclMismatch` instead of `PasswordWrong`
+- **`-128` error mapping**: `errSecUserCanceled` now maps to `Error::UserCanceled` (dedicated variant) instead of a generic `Error::Keychain` string
+
+### Changed
+
+- `lkr harden` UX overhaul:
+  - Pre-flight briefing explains upcoming macOS dialogs and recommends "Always Allow"
+  - Progress counter: `[1/5] key-name — hardened / skipped / FAILED`
+  - Dialog deny → `skipped (denied)` with re-run guidance
+  - Set failure → warns about potential key loss with `lkr set` recovery instructions
+  - GUI-less environment (SSH, CI, launchd) → dedicated error message
+  - `--dry-run` now warns about dialog prompts in live mode
+- SECURITY.md roadmap: v0.3.4 = harden fix, v0.3.5 = doctor (shifted)
+
+### Security
+
+- `get_interactive()` is `pub` + `#[doc(hidden)]` on `KeychainStore` — not on the `KeyStore` trait. This prevents accidental use outside `lkr harden`. Normal reads remain non-interactive
+- Note: macOS "Always Allow" granularity (per-cdhash vs per-app) is not fully verified. `set` rebuilds explicit ACL regardless, so the final security posture is correct
+
 ## [0.3.3] - 2026-03-13
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,25 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`lkr harden` ACL chicken-and-egg**: after `brew upgrade`, the binary's cdhash changes and all keys become ACL-blocked. `harden` now uses interactive Keychain access (macOS authorization dialog) to read key values before re-creating them with a fresh ACL. Previously, `harden` tried non-interactive reads, which failed immediately on every key
+- **`lkr harden` ACL chicken-and-egg**: after `brew upgrade`, the binary's cdhash changes and all keys become ACL-blocked. `harden` now uses interactive Keychain access to read key values before re-creating them with a fresh ACL. Previously, `harden` tried non-interactive reads, which failed immediately on every key
+- **`harden` delete/set failed with PasswordWrong**: `delete_v3` and `set_v3` used `disable_user_interaction`, which blocked ACL-mismatched operations. Added interactive variants (`delete_v3_interactive`, `set_v3_interactive`) used by `harden`
+- **`exists()` misreported PasswordWrong**: when `get_v3` returned `-25293` with null `item_ref`, the ACL mismatch check was skipped, causing `exists()` to propagate `PasswordWrong` instead of returning `true`. Now treats `PasswordWrong` as `exists=true` in custom keychain context
 - **`-25293` misdiagnosed as wrong password**: `errSecAuthFailed` from `SecKeychainFindGenericPassword` is now checked for ACL cdhash mismatch (same as `-25308`), returning `AclMismatch` instead of `PasswordWrong`
 - **`-128` error mapping**: `errSecUserCanceled` now maps to `Error::UserCanceled` (dedicated variant) instead of a generic `Error::Keychain` string
 
 ### Changed
 
 - `lkr harden` UX overhaul:
-  - Pre-flight briefing explains upcoming macOS dialogs and recommends "Always Allow"
   - Progress counter: `[1/5] key-name — hardened / skipped / FAILED`
-  - Dialog deny → `skipped (denied)` with re-run guidance
   - Set failure → warns about potential key loss with `lkr set` recovery instructions
-  - GUI-less environment (SSH, CI, launchd) → dedicated error message
-  - `--dry-run` now warns about dialog prompts in live mode
+  - `--dry-run` lists keys and explains what will happen
+  - Messages updated to reflect custom keychain behavior (dialogs may not appear)
 - SECURITY.md roadmap: v0.3.4 = harden fix, v0.3.5 = doctor (shifted)
 
 ### Security
 
-- `get_interactive()` is `pub` + `#[doc(hidden)]` on `KeychainStore` — not on the `KeyStore` trait. This prevents accidental use outside `lkr harden`. Normal reads remain non-interactive
-- Note: macOS "Always Allow" granularity (per-cdhash vs per-app) is not fully verified. `set` rebuilds explicit ACL regardless, so the final security posture is correct
+- `get_interactive()` and `set_interactive()` are `pub` + `#[doc(hidden)]` on `KeychainStore` — not on the `KeyStore` trait. This prevents accidental use outside `lkr harden`. Normal reads/writes remain non-interactive
+- Custom keychains bypass ACL checks when unlocked; `harden` still re-applies ACL for defense-in-depth
 
 ## [0.3.3] - 2026-03-13
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -902,7 +902,7 @@ checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lkr-cli"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "arboard",
  "clap",
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "lkr-core"
-version = "0.3.2"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "core-foundation 0.10.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/lkr-core", "crates/lkr-cli"]
 resolver = "2"
 
 [workspace.package]
-version = "0.3.3"
+version = "0.3.4"
 edition = "2024"
 rust-version = "1.85"
 license = "MIT OR Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -45,10 +45,6 @@ Requires macOS (uses native Keychain). Source build requires Rust 1.85+.
 
 > **Note**: After upgrading (`brew upgrade lkr` or `cargo install --force`), run `lkr harden`
 > to refresh Keychain ACL for the new binary.
->
-> **Known issue (v0.3.3)**: `lkr harden` currently fails after binary update due to an ACL
-> chicken-and-egg problem ([#13](https://github.com/yottayoshida/llm-key-ring/issues/13)).
-> Fix planned for v0.3.4.
 
 ## Usage
 
@@ -357,8 +353,9 @@ remain readable via v0.2.x fallback until you manually remove them.
 | **v0.3.0** | **Security: 3-Layer Defense** | Custom Keychain (`lkr.keychain-db`) + Legacy ACL via Pure FFI + cdhash. **Breaking change** — see below |
 | **v0.3.1** | **Security Hardening** | ACL fail-closed, `keychain_path()` safety, `StoredEntry` zeroize-on-drop, `-25308` auto-diagnosis |
 | **v0.3.2** | **Operational Quality** | List N+1 fix, CLI module split, unsafe SAFETY docs, Homebrew tap |
-| **v0.3.3** (current) | **Bug Fix** | `lkr migrate` circular error fix |
-| v0.3.4 | Diagnostics | `lkr doctor` (Keychain health check) |
+| **v0.3.3** | **Bug Fix** | `lkr migrate` circular error fix |
+| **v0.3.4** (current) | **Bug Fix** | `lkr harden` ACL fix after binary update ([#13](https://github.com/yottayoshida/llm-key-ring/issues/13)) |
+| v0.3.5 | Diagnostics | `lkr doctor` (Keychain health check) |
 | v0.4.0 | MCP Server | IDE integration for secure key access |
 
 ## Development

--- a/crates/lkr-cli/src/cmd/harden.rs
+++ b/crates/lkr-cli/src/cmd/harden.rs
@@ -55,12 +55,8 @@ pub(crate) fn cmd_harden(store: &KeychainStore, dry_run: bool) -> lkr_core::Resu
             }
             Err(Error::InteractionNotAllowed) => {
                 eprintln!("FAILED");
-                eprintln!(
-                    "         `lkr harden` requires a GUI environment (macOS desktop)."
-                );
-                eprintln!(
-                    "         It cannot run over SSH, in CI, or as a launchd service."
-                );
+                eprintln!("         `lkr harden` requires a GUI environment (macOS desktop).");
+                eprintln!("         It cannot run over SSH, in CI, or as a launchd service.");
                 fail_count += 1;
                 continue;
             }
@@ -79,9 +75,7 @@ pub(crate) fn cmd_harden(store: &KeychainStore, dry_run: bool) -> lkr_core::Resu
             }
             Err(e) => {
                 eprintln!("FAILED to re-create: {}", e);
-                eprintln!(
-                    "         ⚠ The key may have been deleted during this operation."
-                );
+                eprintln!("         ⚠ The key may have been deleted during this operation.");
                 eprintln!(
                     "         Recovery: `lkr set {} --kind {}` to re-register.",
                     entry.name, kind

--- a/crates/lkr-cli/src/cmd/harden.rs
+++ b/crates/lkr-cli/src/cmd/harden.rs
@@ -1,3 +1,4 @@
+use lkr_core::error::Error;
 use lkr_core::{KeyStore, KeychainStore};
 
 /// Re-apply ACL to all keys (after binary update/reinstall).
@@ -11,46 +12,108 @@ pub(crate) fn cmd_harden(store: &KeychainStore, dry_run: bool) -> lkr_core::Resu
         return Ok(());
     }
 
+    let total = entries.len();
+
     if dry_run {
-        eprintln!("  Would re-apply ACL to {} key(s):", entries.len());
+        eprintln!("  Would re-apply ACL to {} key(s):", total);
         for entry in &entries {
             eprintln!("    {} ({})", entry.name, entry.kind_display());
         }
+        eprintln!();
+        eprintln!("  Note: Running without --dry-run will show a macOS authorization");
+        eprintln!("  dialog for each key whose ACL no longer matches this binary.");
         eprintln!("\n  Run `lkr harden` (without --dry-run) to apply.");
         return Ok(());
     }
 
-    // Harden: delete + re-create with fresh ACL for each key
-    let mut success_count = 0;
-    let mut fail_count = 0;
+    // --- Pre-flight briefing ---
+    eprintln!("Hardening {} key(s)...", total);
+    eprintln!();
+    eprintln!("  macOS will show an authorization dialog for each key whose ACL");
+    eprintln!("  no longer matches this binary (e.g. after brew upgrade).");
+    eprintln!();
+    eprintln!("  Tip: Click \"Always Allow\" to avoid repeated prompts for");
+    eprintln!("  the same key on future reads.");
+    eprintln!();
 
-    for entry in &entries {
-        // Read current value
-        let (value, kind) = match store.get(&entry.name) {
+    // --- Harden loop: interactive-get → delete → set with fresh ACL ---
+    let mut success_count: usize = 0;
+    let mut skip_count: usize = 0;
+    let mut fail_count: usize = 0;
+
+    for (i, entry) in entries.iter().enumerate() {
+        let idx = i + 1;
+        eprint!("  [{}/{}] {} — ", idx, total, entry.name);
+
+        // Step 1: Read current value via interactive dialog
+        let (value, kind) = match store.get_interactive(&entry.name) {
             Ok(v) => v,
+            Err(Error::UserCanceled) => {
+                eprintln!("skipped (denied)");
+                skip_count += 1;
+                continue;
+            }
+            Err(Error::InteractionNotAllowed) => {
+                eprintln!("FAILED");
+                eprintln!(
+                    "         `lkr harden` requires a GUI environment (macOS desktop)."
+                );
+                eprintln!(
+                    "         It cannot run over SSH, in CI, or as a launchd service."
+                );
+                fail_count += 1;
+                continue;
+            }
             Err(e) => {
-                eprintln!("    {} — FAILED to read: {}", entry.name, e);
+                eprintln!("FAILED to read: {}", e);
                 fail_count += 1;
                 continue;
             }
         };
 
-        // Delete + re-create with force (which triggers CreateFromContent with fresh ACL)
+        // Step 2: Re-create with fresh ACL (set with force deletes + re-creates)
         match store.set(&entry.name, &value, kind, true) {
             Ok(()) => {
-                eprintln!("    {} — hardened", entry.name);
+                eprintln!("hardened");
                 success_count += 1;
             }
             Err(e) => {
-                eprintln!("    {} — FAILED: {}", entry.name, e);
+                eprintln!("FAILED to re-create: {}", e);
+                eprintln!(
+                    "         ⚠ The key may have been deleted during this operation."
+                );
+                eprintln!(
+                    "         Recovery: `lkr set {} --kind {}` to re-register.",
+                    entry.name, kind
+                );
                 fail_count += 1;
             }
         }
     }
 
+    // --- Summary ---
+    eprintln!();
     eprintln!(
-        "\n  Result: {} hardened, {} failed",
-        success_count, fail_count
+        "  Result: {} hardened, {} skipped, {} failed",
+        success_count, skip_count, fail_count
     );
+
+    if skip_count > 0 {
+        eprintln!();
+        eprintln!("  Skipped keys can be hardened by running `lkr harden` again");
+        eprintln!("  and clicking \"Allow\" or \"Always Allow\" in the dialog.");
+    }
+
+    if fail_count > 0 {
+        eprintln!();
+        eprintln!("  Failed keys may need manual recovery with `lkr set`.");
+    }
+
+    if success_count > 0 && skip_count == 0 && fail_count == 0 {
+        eprintln!();
+        eprintln!("  All keys hardened successfully. If you clicked \"Always Allow\",");
+        eprintln!("  future `lkr get` calls will work without any dialog.");
+    }
+
     Ok(())
 }

--- a/crates/lkr-cli/src/cmd/harden.rs
+++ b/crates/lkr-cli/src/cmd/harden.rs
@@ -67,8 +67,9 @@ pub(crate) fn cmd_harden(store: &KeychainStore, dry_run: bool) -> lkr_core::Resu
             }
         };
 
-        // Step 2: Re-create with fresh ACL (set with force deletes + re-creates)
-        match store.set(&entry.name, &value, kind, true) {
+        // Step 2: Re-create with fresh ACL (interactive: allows macOS dialog
+        // for delete/set when ACL cdhash no longer matches this binary)
+        match store.set_interactive(&entry.name, &value, kind, true) {
             Ok(()) => {
                 eprintln!("hardened");
                 success_count += 1;

--- a/crates/lkr-cli/src/cmd/harden.rs
+++ b/crates/lkr-cli/src/cmd/harden.rs
@@ -20,8 +20,8 @@ pub(crate) fn cmd_harden(store: &KeychainStore, dry_run: bool) -> lkr_core::Resu
             eprintln!("    {} ({})", entry.name, entry.kind_display());
         }
         eprintln!();
-        eprintln!("  Note: Running without --dry-run will show a macOS authorization");
-        eprintln!("  dialog for each key whose ACL no longer matches this binary.");
+        eprintln!("  Note: Running without --dry-run will re-apply ACL to each key.");
+        eprintln!("  macOS may show an authorization dialog if needed.");
         eprintln!("\n  Run `lkr harden` (without --dry-run) to apply.");
         return Ok(());
     }
@@ -29,11 +29,8 @@ pub(crate) fn cmd_harden(store: &KeychainStore, dry_run: bool) -> lkr_core::Resu
     // --- Pre-flight briefing ---
     eprintln!("Hardening {} key(s)...", total);
     eprintln!();
-    eprintln!("  macOS will show an authorization dialog for each key whose ACL");
-    eprintln!("  no longer matches this binary (e.g. after brew upgrade).");
-    eprintln!();
-    eprintln!("  Tip: Click \"Always Allow\" to avoid repeated prompts for");
-    eprintln!("  the same key on future reads.");
+    eprintln!("  Re-applying ACL for the current binary. macOS may show an");
+    eprintln!("  authorization dialog if the keychain requires it.");
     eprintln!();
 
     // --- Harden loop: interactive-get → delete → set with fresh ACL ---
@@ -106,8 +103,7 @@ pub(crate) fn cmd_harden(store: &KeychainStore, dry_run: bool) -> lkr_core::Resu
 
     if success_count > 0 && skip_count == 0 && fail_count == 0 {
         eprintln!();
-        eprintln!("  All keys hardened successfully. If you clicked \"Always Allow\",");
-        eprintln!("  future `lkr get` calls will work without any dialog.");
+        eprintln!("  All keys hardened successfully.");
     }
 
     Ok(())

--- a/crates/lkr-core/src/error.rs
+++ b/crates/lkr-core/src/error.rs
@@ -53,6 +53,9 @@ pub enum Error {
 
     #[error("Keychain operation requires user interaction, which is disabled")]
     InteractionNotAllowed,
+
+    #[error("Operation canceled by user")]
+    UserCanceled,
 }
 
 /// OSStatus codes from Security.framework.
@@ -128,5 +131,13 @@ mod tests {
         let msg = e.to_string();
         assert!(msg.contains("openai:prod"));
         assert!(msg.contains("--force"));
+    }
+
+    #[test]
+    fn test_error_display_user_canceled() {
+        let e = Error::UserCanceled;
+        let msg = e.to_string();
+        assert!(msg.contains("canceled"));
+        assert!(!msg.contains("cdhash"));
     }
 }

--- a/crates/lkr-core/src/keymanager.rs
+++ b/crates/lkr-core/src/keymanager.rs
@@ -1395,6 +1395,10 @@ impl KeyStore for KeychainStore {
                 Ok(_) => Ok(true),
                 Err(Error::KeyNotFound { .. }) => Ok(false),
                 Err(Error::AclMismatch) => Ok(true), // key exists but ACL blocks read
+                // When user-interaction is disabled, macOS may return
+                // errSecAuthFailed (-25293) instead of a distinct ACL error
+                // if item_ref is null. The key still exists.
+                Err(Error::PasswordWrong) => Ok(true),
                 Err(e) => Err(e),
             }
         } else {

--- a/crates/lkr-core/src/keymanager.rs
+++ b/crates/lkr-core/src/keymanager.rs
@@ -307,9 +307,7 @@ mod keychain_raw {
             ERR_SEC_DECODE_ERROR => Error::Keychain(
                 "Failed to decode keychain data. The keychain file may be corrupted.".into(),
             ),
-            ERR_SEC_USER_CANCELED => Error::Keychain(
-                "Operation was canceled. This may indicate a GUI dialog was suppressed.".into(),
-            ),
+            ERR_SEC_USER_CANCELED => Error::UserCanceled,
             _ => Error::Keychain(format!("Keychain error: OSStatus {status}")),
         }
     }
@@ -531,18 +529,58 @@ mod keychain_raw {
 
     /// Retrieve password bytes from Custom Keychain (v0.3.0).
     ///
-    /// Uses `SecKeychainFindGenericPassword` scoped to the given keychain.
-    /// Returns the raw bytes and optionally the item ref (for ACL diagnosis).
+    /// Non-interactive: user-interaction is disabled so ACL-blocked keys
+    /// return `Error::AclMismatch` instead of prompting a macOS dialog.
     pub(super) fn get_v3(
         keychain: &security_framework::os::macos::keychain::SecKeychain,
         service: &str,
         account: &str,
     ) -> Result<Vec<u8>> {
+        get_v3_inner(keychain, service, account, false)
+    }
+
+    /// Retrieve password bytes with user-interaction enabled.
+    ///
+    /// When ACL cdhash no longer matches the running binary (e.g. after
+    /// `brew upgrade`), macOS will show a one-time "Allow" dialog per key.
+    ///
+    /// # Security
+    /// This is an escape hatch for `lkr harden` only.  Normal `lkr get`
+    /// must always use `get_v3` (non-interactive) so that no dialog is
+    /// shown during programmatic access.
+    pub(super) fn get_v3_interactive(
+        keychain: &security_framework::os::macos::keychain::SecKeychain,
+        service: &str,
+        account: &str,
+    ) -> Result<Vec<u8>> {
+        get_v3_inner(keychain, service, account, true)
+    }
+
+    /// Inner implementation shared by `get_v3` / `get_v3_interactive`.
+    ///
+    /// `interactive`:
+    ///   - `false` — disable user-interaction (default for all reads)
+    ///   - `true`  — allow macOS to present an authorization dialog
+    fn get_v3_inner(
+        keychain: &security_framework::os::macos::keychain::SecKeychain,
+        service: &str,
+        account: &str,
+        interactive: bool,
+    ) -> Result<Vec<u8>> {
         use core_foundation::base::TCFType;
         use security_framework::os::macos::keychain::SecKeychain;
 
-        let _guard = SecKeychain::disable_user_interaction()
-            .map_err(|e| Error::Keychain(format!("Failed to disable user interaction: {e}")))?;
+        // Only acquire the interaction-guard when non-interactive.
+        // The guard is held until this scope ends, suppressing macOS dialogs.
+        let _guard = if !interactive {
+            Some(
+                SecKeychain::disable_user_interaction().map_err(|e| {
+                    Error::Keychain(format!("Failed to disable user interaction: {e}"))
+                })?,
+            )
+        } else {
+            None
+        };
 
         let svc_bytes = service.as_bytes();
         let acct_bytes = account.as_bytes();
@@ -569,8 +607,11 @@ mod keychain_raw {
         };
 
         if status != 0 {
-            // Harden -25308: distinguish ACL mismatch from keychain-locked
-            if status == crate::error::os_status::ERR_SEC_INTERACTION_NOT_ALLOWED
+            // -25308 (InteractionNotAllowed) or -25293 (AuthFailed): may
+            // indicate ACL cdhash mismatch when user-interaction is disabled.
+            // Check the item's ACL to distinguish from genuine auth errors.
+            if (status == crate::error::os_status::ERR_SEC_INTERACTION_NOT_ALLOWED
+                || status == crate::error::os_status::ERR_SEC_AUTH_FAILED)
                 && !item_ref.is_null()
             {
                 // SAFETY: item_ref is non-null (checked above), valid
@@ -892,6 +933,41 @@ impl KeychainStore {
         self.custom_keychain.is_some()
     }
 
+    /// Read a key value via interactive macOS dialog (allows "Allow" prompt).
+    ///
+    /// # Security
+    /// **This is an escape hatch for `lkr harden` only.**  It bypasses the
+    /// `disable_user_interaction` guard so that macOS can present a keychain
+    /// authorization dialog when the binary's cdhash no longer matches the
+    /// ACL (e.g. after `brew upgrade`).
+    ///
+    /// Normal key reads must always go through [`KeyStore::get`] which keeps
+    /// user-interaction disabled.
+    #[doc(hidden)]
+    pub fn get_interactive(&self, name: &str) -> Result<(Zeroizing<String>, KeyKind)> {
+        validate_name(name)?;
+
+        let kc = self.custom_keychain.as_ref().ok_or_else(|| {
+            Error::Keychain("get_interactive requires v0.3.0 Custom Keychain".into())
+        })?;
+
+        let bytes = keychain_raw::get_v3_interactive(kc, &self.service, name)?;
+        Self::parse_stored_bytes(bytes)
+    }
+
+    /// Parse raw Keychain bytes into (value, kind).
+    /// Shared by `get` and `get_interactive` to avoid duplication.
+    fn parse_stored_bytes(bytes: Vec<u8>) -> Result<(Zeroizing<String>, KeyKind)> {
+        let json = Zeroizing::new(
+            String::from_utf8(bytes)
+                .map_err(|e| Error::Keychain(format!("Invalid UTF-8 in key data: {e}")))?,
+        );
+        let mut stored: StoredEntry = serde_json::from_str(&json)
+            .map_err(|e| Error::Keychain(format!("Failed to deserialize stored entry: {e}")))?;
+        let value = std::mem::take(&mut stored.value);
+        Ok((Zeroizing::new(value), stored.kind))
+    }
+
     /// Extract the account name (kSecAttrAccount) from a CFDictionary.
     /// Returns None if the attribute is missing or not a valid string.
     fn extract_account(dict: &core_foundation::dictionary::CFDictionary) -> Option<String> {
@@ -1076,16 +1152,7 @@ impl KeyStore for KeychainStore {
             keychain_raw::get(&self.service, name)?
         };
 
-        let json = Zeroizing::new(
-            String::from_utf8(bytes)
-                .map_err(|e| Error::Keychain(format!("Invalid UTF-8 in Keychain: {}", e)))?,
-        );
-
-        let mut stored: StoredEntry = serde_json::from_str(&json)
-            .map_err(|e| Error::Keychain(format!("Failed to deserialize: {}", e)))?;
-
-        let value = std::mem::take(&mut stored.value);
-        Ok((Zeroizing::new(value), stored.kind))
+        Self::parse_stored_bytes(bytes)
     }
 
     fn delete(&self, name: &str) -> Result<()> {

--- a/crates/lkr-core/src/keymanager.rs
+++ b/crates/lkr-core/src/keymanager.rs
@@ -572,15 +572,14 @@ mod keychain_raw {
 
         // Only acquire the interaction-guard when non-interactive.
         // The guard is held until this scope ends, suppressing macOS dialogs.
-        let _guard = if !interactive {
-            Some(
-                SecKeychain::disable_user_interaction().map_err(|e| {
+        let _guard =
+            if !interactive {
+                Some(SecKeychain::disable_user_interaction().map_err(|e| {
                     Error::Keychain(format!("Failed to disable user interaction: {e}"))
-                })?,
-            )
-        } else {
-            None
-        };
+                })?)
+            } else {
+                None
+            };
 
         let svc_bytes = service.as_bytes();
         let acct_bytes = account.as_bytes();

--- a/crates/lkr-core/src/keymanager.rs
+++ b/crates/lkr-core/src/keymanager.rs
@@ -467,11 +467,42 @@ mod keychain_raw {
         account: &str,
         password: &[u8],
     ) -> Result<()> {
+        set_v3_inner(keychain, access, service, account, password, false)
+    }
+
+    /// Store a password with user-interaction enabled.
+    ///
+    /// Used by `lkr harden` where macOS may need to show a dialog.
+    pub(super) fn set_v3_interactive(
+        keychain: &security_framework::os::macos::keychain::SecKeychain,
+        access: *const c_void,
+        service: &str,
+        account: &str,
+        password: &[u8],
+    ) -> Result<()> {
+        set_v3_inner(keychain, access, service, account, password, true)
+    }
+
+    /// Inner implementation shared by `set_v3` / `set_v3_interactive`.
+    fn set_v3_inner(
+        keychain: &security_framework::os::macos::keychain::SecKeychain,
+        access: *const c_void,
+        service: &str,
+        account: &str,
+        password: &[u8],
+        interactive: bool,
+    ) -> Result<()> {
         use core_foundation::base::TCFType;
         use security_framework::os::macos::keychain::SecKeychain;
 
-        let _guard = SecKeychain::disable_user_interaction()
-            .map_err(|e| Error::Keychain(format!("Failed to disable user interaction: {e}")))?;
+        let _guard =
+            if !interactive {
+                Some(SecKeychain::disable_user_interaction().map_err(|e| {
+                    Error::Keychain(format!("Failed to disable user interaction: {e}"))
+                })?)
+            } else {
+                None
+            };
 
         let svc_bytes = service.as_bytes();
         let acct_bytes = account.as_bytes();
@@ -658,18 +689,46 @@ mod keychain_raw {
 
     /// Delete a key from Custom Keychain (v0.3.0).
     ///
-    /// Finds the item via `SecKeychainFindGenericPassword`, then deletes it
-    /// via `SecKeychainItemDelete`.
+    /// Non-interactive: user-interaction is disabled (default for all
+    /// programmatic operations).
     pub(super) fn delete_v3(
         keychain: &security_framework::os::macos::keychain::SecKeychain,
         service: &str,
         account: &str,
     ) -> Result<()> {
+        delete_v3_inner(keychain, service, account, false)
+    }
+
+    /// Delete a key with user-interaction enabled.
+    ///
+    /// Used by `lkr harden` where ACL cdhash no longer matches the
+    /// running binary. macOS may show a dialog to authorize deletion.
+    pub(super) fn delete_v3_interactive(
+        keychain: &security_framework::os::macos::keychain::SecKeychain,
+        service: &str,
+        account: &str,
+    ) -> Result<()> {
+        delete_v3_inner(keychain, service, account, true)
+    }
+
+    /// Inner implementation shared by `delete_v3` / `delete_v3_interactive`.
+    fn delete_v3_inner(
+        keychain: &security_framework::os::macos::keychain::SecKeychain,
+        service: &str,
+        account: &str,
+        interactive: bool,
+    ) -> Result<()> {
         use core_foundation::base::TCFType;
         use security_framework::os::macos::keychain::SecKeychain;
 
-        let _guard = SecKeychain::disable_user_interaction()
-            .map_err(|e| Error::Keychain(format!("Failed to disable user interaction: {e}")))?;
+        let _guard =
+            if !interactive {
+                Some(SecKeychain::disable_user_interaction().map_err(|e| {
+                    Error::Keychain(format!("Failed to disable user interaction: {e}"))
+                })?)
+            } else {
+                None
+            };
 
         let svc_bytes = service.as_bytes();
         let acct_bytes = account.as_bytes();
@@ -952,6 +1011,74 @@ impl KeychainStore {
 
         let bytes = keychain_raw::get_v3_interactive(kc, &self.service, name)?;
         Self::parse_stored_bytes(bytes)
+    }
+
+    /// Re-create a key with user-interaction enabled (allows macOS dialog).
+    ///
+    /// # Security
+    /// **This is an escape hatch for `lkr harden` only.** When ACL cdhash
+    /// no longer matches the running binary, non-interactive delete/set will
+    /// fail with `-25293 (errSecAuthFailed)`. This method allows macOS to
+    /// present authorization dialogs for both delete and set operations.
+    ///
+    /// Normal key writes must always go through [`KeyStore::set`] which keeps
+    /// user-interaction disabled.
+    #[doc(hidden)]
+    pub fn set_interactive(
+        &self,
+        name: &str,
+        value: &str,
+        kind: KeyKind,
+        force: bool,
+    ) -> Result<()> {
+        validate_name(name)?;
+        if value.is_empty() {
+            return Err(Error::EmptyValue);
+        }
+
+        let kc = self.custom_keychain.as_ref().ok_or_else(|| {
+            Error::Keychain("set_interactive requires v0.3.0 Custom Keychain".into())
+        })?;
+
+        let exists = self.exists(name)?;
+        if !force && exists {
+            return Err(Error::KeyAlreadyExists {
+                name: name.to_string(),
+            });
+        }
+
+        let stored = StoredEntry {
+            value: value.to_string(),
+            kind,
+        };
+        let json = Zeroizing::new(
+            serde_json::to_string(&stored)
+                .map_err(|e| Error::Keychain(format!("Failed to serialize: {}", e)))?,
+        );
+
+        let access =
+            crate::acl::current_binary_path().and_then(|p| crate::acl::build_access(&p))?;
+
+        if exists {
+            keychain_raw::delete_v3_interactive(kc, &self.service, name)?;
+        }
+
+        let result =
+            keychain_raw::set_v3_interactive(kc, access, &self.service, name, json.as_bytes());
+
+        if !access.is_null() {
+            // SAFETY: access was returned by build_access() (Create Rule),
+            // retain count == 1. CFRelease is safe here.
+            unsafe {
+                unsafe extern "C" {
+                    fn CFRelease(cf: *const c_void);
+                }
+                CFRelease(access as _);
+            }
+        }
+
+        result?;
+        Ok(())
     }
 
     /// Parse raw Keychain bytes into (value, kind).

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -357,7 +357,8 @@ enabling kind-based access control without separate metadata storage.
 | **v0.3.1** | Security hardening: ACL fail-closed, zeroize-on-drop, `-25308` auto-diagnosis |
 | **v0.3.2** | Operational quality: list N+1 fix, CLI module split, Homebrew tap |
 | **v0.3.3** (current) | Bug fix: `lkr migrate` circular error |
-| v0.3.4 | Diagnostics: `lkr doctor` (search list pollution, ACL/cdhash integrity check) |
+| v0.3.4 | Fix: `lkr harden` ACL chicken-and-egg — interactive get for cdhash mismatch recovery |
+| v0.3.5 | Diagnostics: `lkr doctor` (search list pollution, ACL/cdhash integrity check) |
 | v0.4.0 | MCP server with scoped access tokens |
 
 ## Reporting Security Issues

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -356,8 +356,8 @@ enabling kind-based access control without separate metadata storage.
 | **v0.3.0** | Custom Keychain + Legacy ACL via Pure FFI (3-layer defense: isolation + cdhash authorization + binary integrity) |
 | **v0.3.1** | Security hardening: ACL fail-closed, zeroize-on-drop, `-25308` auto-diagnosis |
 | **v0.3.2** | Operational quality: list N+1 fix, CLI module split, Homebrew tap |
-| **v0.3.3** (current) | Bug fix: `lkr migrate` circular error |
-| v0.3.4 | Fix: `lkr harden` ACL chicken-and-egg — interactive get for cdhash mismatch recovery |
+| **v0.3.3** | Bug fix: `lkr migrate` circular error |
+| **v0.3.4** (current) | Fix: `lkr harden` ACL chicken-and-egg — interactive get/set for cdhash mismatch recovery; `exists()` `-25293` fix |
 | v0.3.5 | Diagnostics: `lkr doctor` (search list pollution, ACL/cdhash integrity check) |
 | v0.4.0 | MCP server with scoped access tokens |
 


### PR DESCRIPTION
## Summary

- `lkr harden` now uses interactive Keychain access (macOS authorization dialog) to read key values when ACL cdhash no longer matches the running binary (e.g. after `brew upgrade`)
- Fix `-25293` (errSecAuthFailed) misdiagnosed as `PasswordWrong` — now correctly returns `AclMismatch` when ACL cdhash mismatch is detected
- Add `Error::UserCanceled` variant for `-128` (errSecUserCanceled) to distinguish dialog-denied from other Keychain errors
- Harden UX overhaul: pre-flight briefing, progress counter `[1/N]`, deny → `skipped (denied)`, set failure → key loss warning with recovery command, GUI-less environment detection
- Extract `parse_stored_bytes()` helper to deduplicate `get` / `get_interactive` JSON parse logic

## Security Notes

- `get_interactive()` is `pub` + `#[doc(hidden)]` on `KeychainStore` only — **not** on the `KeyStore` trait. Normal `lkr get` remains non-interactive
- Known limitation: delete → set_v3 is non-atomic. Recovery message is shown on set failure

## Test plan

- [ ] `cargo test` passes (unit tests including new `UserCanceled` display test)
- [ ] `cargo clippy -- -D warnings` clean
- [ ] Manual: `lkr harden` after cdhash change — dialog per key, "hardened" on Allow
- [ ] Manual: `lkr harden` — click Deny → "skipped (denied)", re-run works
- [ ] Manual: `lkr harden --dry-run` — no dialog, shows warning about live mode
- [ ] Manual: `lkr get` — no dialog (regression check)
- [ ] Manual: 0 keys → "No keys to harden."

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)