### PR TITLE
fix(deps): switch reqwest TLS stack to rustls-native-roots, clear RustSec advisories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`lkr usage` TLS stack**: switched from `native-tls` (Secure Transport) to `rustls` with the system trust store (`rustls-native-certs`), removing the native-tls/OpenSSL dependency chain from the binary. This resolves 5 RustSec advisories that had accumulated in `Cargo.lock` (`quinn-proto` RUSTSEC-2026-0185, `rustls-webpki` RUSTSEC-2026-0104/0098/0099/0049). Root CA trust is drawn from the OS trust store rather than a bundled snapshot; `usage` request-failure errors now include a hint for connection-level failures (covers network/DNS issues as well as corporate proxy/CA environments — not a diagnosis, just a pointer)
+- **`lkr usage` TLS stack**: switched from `native-tls` (Secure Transport) to `rustls` with the system trust store (`rustls-native-certs`), removing the native-tls/OpenSSL dependency chain — and the compiled-but-unused `webpki-roots` bundled snapshot — from the binary. This resolves 5 RustSec advisories that had accumulated in `Cargo.lock` (`quinn-proto` RUSTSEC-2026-0185, `rustls-webpki` RUSTSEC-2026-0104/0098/0099/0049). Root CA trust was already drawn from the OS trust store before this change (via Secure Transport) and still is now (via `rustls-native-certs`) — this is a TLS backend swap, not a change in which CAs are trusted; `usage` request-failure errors now include a hint for connection-level failures (covers network/DNS issues as well as corporate proxy/CA environments — not a diagnosis, just a pointer)
 
 ## [0.3.4] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`lkr usage` TLS stack**: switched from `native-tls` (Secure Transport) to `rustls` with the system trust store (`rustls-native-certs`), removing the native-tls/OpenSSL dependency chain from the binary. This resolves 5 RustSec advisories that had accumulated in `Cargo.lock` (`quinn-proto` RUSTSEC-2026-0185, `rustls-webpki` RUSTSEC-2026-0104/0098/0099/0049). Root CA trust is drawn from the OS trust store rather than a bundled snapshot; if `lkr usage` fails behind a corporate proxy/CA, the error now includes a hint pointing at that possibility
-- `usage` request-failure errors now include a hint for connection-level failures that may indicate a corporate CA or proxy environment
+- **`lkr usage` TLS stack**: switched from `native-tls` (Secure Transport) to `rustls` with the system trust store (`rustls-native-certs`), removing the native-tls/OpenSSL dependency chain from the binary. This resolves 5 RustSec advisories that had accumulated in `Cargo.lock` (`quinn-proto` RUSTSEC-2026-0185, `rustls-webpki` RUSTSEC-2026-0104/0098/0099/0049). Root CA trust is drawn from the OS trust store rather than a bundled snapshot; `usage` request-failure errors now include a hint for connection-level failures that may indicate a corporate CA or proxy environment
 
 ## [0.3.4] - 2026-03-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **`lkr usage` TLS stack**: switched from `native-tls` (Secure Transport) to `rustls` with the system trust store (`rustls-native-certs`), removing the native-tls/OpenSSL dependency chain from the binary. This resolves 5 RustSec advisories that had accumulated in `Cargo.lock` (`quinn-proto` RUSTSEC-2026-0185, `rustls-webpki` RUSTSEC-2026-0104/0098/0099/0049). Root CA trust is drawn from the OS trust store rather than a bundled snapshot; if `lkr usage` fails behind a corporate proxy/CA, the error now includes a hint pointing at that possibility
+- `usage` request-failure errors now include a hint for connection-level failures that may indicate a corporate CA or proxy environment
+
 ## [0.3.4] - 2026-03-14
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`lkr usage` TLS stack**: switched from `native-tls` (Secure Transport) to `rustls` with the system trust store (`rustls-native-certs`), removing the native-tls/OpenSSL dependency chain from the binary. This resolves 5 RustSec advisories that had accumulated in `Cargo.lock` (`quinn-proto` RUSTSEC-2026-0185, `rustls-webpki` RUSTSEC-2026-0104/0098/0099/0049). Root CA trust is drawn from the OS trust store rather than a bundled snapshot; `usage` request-failure errors now include a hint for connection-level failures that may indicate a corporate CA or proxy environment
+- **`lkr usage` TLS stack**: switched from `native-tls` (Secure Transport) to `rustls` with the system trust store (`rustls-native-certs`), removing the native-tls/OpenSSL dependency chain from the binary. This resolves 5 RustSec advisories that had accumulated in `Cargo.lock` (`quinn-proto` RUSTSEC-2026-0185, `rustls-webpki` RUSTSEC-2026-0104/0098/0099/0049). Root CA trust is drawn from the OS trust store rather than a bundled snapshot; `usage` request-failure errors now include a hint for connection-level failures (covers network/DNS issues as well as corporate proxy/CA environments — not a diagnosis, just a pointer)
 
 ## [0.3.4] - 2026-03-14
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -164,6 +164,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
+name = "chacha20"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "rand_core",
+]
+
+[[package]]
 name = "chrono"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -259,6 +270,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,12 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
-name = "fastrand"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
-
-[[package]]
 name = "fax"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -377,31 +391,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -426,12 +419,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-sink"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
@@ -476,48 +463,18 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi",
- "wasip2",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
-]
-
-[[package]]
-name = "h2"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -610,7 +567,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -632,26 +588,10 @@ dependencies = [
  "hyper",
  "hyper-util",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tower-service",
- "webpki-roots",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
  "tower-service",
 ]
 
@@ -995,23 +935,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1106,48 +1029,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
-name = "openssl"
-version = "0.10.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "once_cell",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.111"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "parking_lot"
@@ -1191,12 +1076,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,15 +1095,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
 ]
 
 [[package]]
@@ -1283,14 +1153,15 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
 dependencies = [
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.4.1",
  "lru-slab",
  "rand",
+ "rand_pcg",
  "ring",
  "rustc-hash",
  "rustls",
@@ -1333,31 +1204,28 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "c7f5fa3a058cd35567ef9bfa5e75732bee0f9e4c55fa90477bef2dfcdbc4be80"
 dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.1",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
+
+[[package]]
+name = "rand_pcg"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa0f4137e1c0a72f4c651489402276c8e8e1cf081f3b0ba156d2cbeef09e86a"
 dependencies = [
- "getrandom 0.3.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1379,29 +1247,26 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
  "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower",
  "tower-http",
@@ -1410,7 +1275,6 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1471,6 +1335,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
 name = "rustls-pki-types"
 version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1482,9 +1358,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -1717,19 +1593,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82a72c767771b47409d2345987fda8628641887d5466101319899796367354a0"
-dependencies = [
- "fastrand",
- "getrandom 0.4.1",
- "once_cell",
- "rustix",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1817,35 +1680,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
- "tokio",
-]
-
-[[package]]
-name = "tokio-util"
-version = "0.7.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-sink",
- "pin-project-lite",
  "tokio",
 ]
 
@@ -1960,12 +1800,6 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "want"
@@ -2111,15 +1945,6 @@ checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
-dependencies = [
- "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
-reqwest = { version = "0.12", features = ["rustls-tls", "json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls-native-roots", "json", "charset", "system-proxy"] }
 chrono = { version = "0.4", features = ["serde"] }
 zeroize = { version = "1", features = ["derive"] }
 security-framework = "3"

--- a/crates/lkr-cli/src/cmd/get.rs
+++ b/crates/lkr-cli/src/cmd/get.rs
@@ -42,7 +42,7 @@ pub(crate) fn cmd_get(
 
     if plain || force_plain {
         // Raw value only, no newline — for piping
-        print!("{}", &*value);
+        print!("{}", *value);
         io::stdout().flush().ok();
         return Ok(());
     }
@@ -81,7 +81,7 @@ pub(crate) fn cmd_get(
         });
         println!("{}", serde_json::to_string_pretty(&obj).unwrap());
     } else if show {
-        println!("{}", &*value);
+        println!("{}", *value);
     } else {
         println!("  {}  ({})", mask_value(&value), kind);
     }

--- a/crates/lkr-core/src/template.rs
+++ b/crates/lkr-core/src/template.rs
@@ -166,7 +166,7 @@ fn generate_env(store: &impl KeyStore, content: &str) -> Result<GenResult> {
             if let Some((key_name, value, alternatives)) =
                 resolve_env_var(store, var_name, &provider_map)
             {
-                output.push_str(&format!("{}={}\n", var_name, &*value));
+                output.push_str(&format!("{}={}\n", var_name, *value));
                 resolutions.push(Resolution {
                     placeholder: var_name.to_string(),
                     key_name: Some(key_name),

--- a/crates/lkr-core/src/usage.rs
+++ b/crates/lkr-core/src/usage.rs
@@ -361,8 +361,19 @@ fn http_client() -> reqwest::Client {
 /// Format a request-failure message, hinting at corporate CA/proxy environments
 /// for connection-level failures (TLS handshake included).
 fn request_failed_msg(provider: &str, e: &reqwest::Error) -> String {
-    let mut msg = format!("{provider} API request failed: {e}");
-    if e.is_connect() {
+    request_failed_msg_from_parts(provider, e, e.is_connect())
+}
+
+/// Pure formatting logic behind [`request_failed_msg`], split out so the
+/// hint-vs-no-hint branch can be tested with deterministic inputs instead of
+/// a live `reqwest::Error`.
+fn request_failed_msg_from_parts(
+    provider: &str,
+    err: impl std::fmt::Display,
+    is_connect: bool,
+) -> String {
+    let mut msg = format!("{provider} API request failed: {err}");
+    if is_connect {
         msg.push_str("\n  Hint: this may be caused by a corporate CA or proxy environment.");
     }
     msg
@@ -554,9 +565,40 @@ mod tests {
         assert!(end >= start);
     }
 
+    // -- request_failed_msg_from_parts: pure logic, deterministic inputs --
+
+    #[test]
+    fn test_request_failed_msg_from_parts_connect_error() {
+        let msg = request_failed_msg_from_parts("OpenAI", "connection refused", true);
+        assert_eq!(
+            msg,
+            "OpenAI API request failed: connection refused\n  \
+             Hint: this may be caused by a corporate CA or proxy environment."
+        );
+    }
+
+    #[test]
+    fn test_request_failed_msg_from_parts_non_connect_error() {
+        let msg = request_failed_msg_from_parts("Anthropic", "invalid response", false);
+        assert_eq!(msg, "Anthropic API request failed: invalid response");
+    }
+
+    #[test]
+    fn test_request_failed_msg_from_parts_preserves_arbitrary_provider() {
+        // Guards against the provider argument being dropped or hardcoded.
+        let msg = request_failed_msg_from_parts("SomeOtherVendor", "boom", false);
+        assert!(msg.starts_with("SomeOtherVendor API request failed: boom"));
+    }
+
+    // -- request_failed_msg: wiring against a real reqwest::Error --
+    // Assertions here stay loose (substring only) since reqwest's Display
+    // text for a live error isn't something this crate should hard-code;
+    // exact message shape is covered by the pure tests above.
+
     #[tokio::test]
-    async fn test_request_failed_msg_hints_on_connect_error() {
-        // Loopback port 1 is refused instantly, no external network required.
+    async fn test_request_failed_msg_wires_real_connect_error() {
+        // Loopback port 1 is refused instantly (ECONNREFUSED) — no external
+        // network required, deterministic on every platform CI runs on.
         let client = reqwest::Client::builder()
             .timeout(Duration::from_secs(2))
             .build()
@@ -568,7 +610,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_request_failed_msg_omits_hint_on_non_connect_error() {
+    async fn test_request_failed_msg_wires_real_non_connect_error() {
         // An invalid URL yields a builder error, not a connect error — no hint expected.
         let client = reqwest::Client::new();
         let err = client.get("not a url").send().await.unwrap_err();

--- a/crates/lkr-core/src/usage.rs
+++ b/crates/lkr-core/src/usage.rs
@@ -205,7 +205,7 @@ async fn fetch_openai_cost(store: &impl KeyStore) -> Result<CostReport> {
         .header("Authorization", format!("Bearer {}", *admin_key))
         .send()
         .await
-        .map_err(|e| Error::Usage(format!("OpenAI API request failed: {}", e)))?;
+        .map_err(|e| Error::Usage(request_failed_msg("OpenAI", &e)))?;
 
     // admin_key is Zeroizing<String>; explicit drop zeroes memory before response parsing
     drop(admin_key);
@@ -301,7 +301,7 @@ async fn fetch_anthropic_cost(store: &impl KeyStore) -> Result<CostReport> {
         .header("anthropic-version", "2023-06-01")
         .send()
         .await
-        .map_err(|e| Error::Usage(format!("Anthropic API request failed: {}", e)))?;
+        .map_err(|e| Error::Usage(request_failed_msg("Anthropic", &e)))?;
 
     drop(admin_key);
 
@@ -356,6 +356,16 @@ fn http_client() -> reqwest::Client {
         .timeout(Duration::from_secs(30))
         .build()
         .unwrap_or_else(|_| reqwest::Client::new())
+}
+
+/// Format a request-failure message, hinting at corporate CA/proxy environments
+/// for connection-level failures (TLS handshake included).
+fn request_failed_msg(provider: &str, e: &reqwest::Error) -> String {
+    let mut msg = format!("{provider} API request failed: {e}");
+    if e.is_connect() {
+        msg.push_str("\n  Hint: this may be caused by a corporate CA or proxy environment.");
+    }
+    msg
 }
 
 /// Check HTTP response status, returning a typed error for auth failures.
@@ -542,5 +552,28 @@ mod tests {
         let (start, end) = current_billing_period();
         assert_eq!(start.day(), 1);
         assert!(end >= start);
+    }
+
+    #[tokio::test]
+    async fn test_request_failed_msg_hints_on_connect_error() {
+        // Loopback port 1 is refused instantly, no external network required.
+        let client = reqwest::Client::builder()
+            .timeout(Duration::from_secs(2))
+            .build()
+            .unwrap();
+        let err = client.get("http://127.0.0.1:1").send().await.unwrap_err();
+        assert!(err.is_connect());
+        let msg = request_failed_msg("Test", &err);
+        assert!(msg.contains("corporate CA or proxy"));
+    }
+
+    #[tokio::test]
+    async fn test_request_failed_msg_omits_hint_on_non_connect_error() {
+        // An invalid URL yields a builder error, not a connect error — no hint expected.
+        let client = reqwest::Client::new();
+        let err = client.get("not a url").send().await.unwrap_err();
+        assert!(!err.is_connect());
+        let msg = request_failed_msg("Test", &err);
+        assert!(!msg.contains("Hint"));
     }
 }

--- a/crates/lkr-core/src/usage.rs
+++ b/crates/lkr-core/src/usage.rs
@@ -3,7 +3,7 @@ use crate::keymanager::KeyStore;
 use chrono::{Datelike, NaiveDate, Utc};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::{Duration, Instant};
 
 // ---------------------------------------------------------------------------
@@ -351,11 +351,21 @@ async fn fetch_anthropic_cost(store: &impl KeyStore) -> Result<CostReport> {
 // ---------------------------------------------------------------------------
 
 /// HTTP client with a 30-second timeout — prevents CLI hangs on stalled APIs.
+///
+/// Built once and cloned (cheap — `Client` is `Arc`-backed): with the
+/// rustls-native-roots feature, building a client reads the OS trust store,
+/// so a fresh client per provider would repeat that read unnecessarily when
+/// `lkr usage` queries more than one provider in a single invocation.
 fn http_client() -> reqwest::Client {
-    reqwest::Client::builder()
-        .timeout(Duration::from_secs(30))
-        .build()
-        .unwrap_or_else(|_| reqwest::Client::new())
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| {
+            reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new())
+        })
+        .clone()
 }
 
 /// Format a request-failure message, hinting at corporate CA/proxy environments
@@ -581,13 +591,6 @@ mod tests {
     fn test_request_failed_msg_from_parts_non_connect_error() {
         let msg = request_failed_msg_from_parts("Anthropic", "invalid response", false);
         assert_eq!(msg, "Anthropic API request failed: invalid response");
-    }
-
-    #[test]
-    fn test_request_failed_msg_from_parts_preserves_arbitrary_provider() {
-        // Guards against the provider argument being dropped or hardcoded.
-        let msg = request_failed_msg_from_parts("SomeOtherVendor", "boom", false);
-        assert!(msg.starts_with("SomeOtherVendor API request failed: boom"));
     }
 
     // -- request_failed_msg: wiring against a real reqwest::Error --

--- a/crates/lkr-core/src/usage.rs
+++ b/crates/lkr-core/src/usage.rs
@@ -202,7 +202,7 @@ async fn fetch_openai_cost(store: &impl KeyStore) -> Result<CostReport> {
     let client = http_client();
     let resp = client
         .get(&url)
-        .header("Authorization", format!("Bearer {}", &*admin_key))
+        .header("Authorization", format!("Bearer {}", *admin_key))
         .send()
         .await
         .map_err(|e| Error::Usage(format!("OpenAI API request failed: {}", e)))?;

--- a/crates/lkr-core/src/usage.rs
+++ b/crates/lkr-core/src/usage.rs
@@ -368,8 +368,10 @@ fn http_client() -> reqwest::Client {
         .clone()
 }
 
-/// Format a request-failure message, hinting at corporate CA/proxy environments
-/// for connection-level failures (TLS handshake included).
+/// Format a request-failure message. For connection-level failures
+/// (`reqwest::Error::is_connect()` — covers TCP refusal/timeout, DNS
+/// resolution, and TLS handshake failures alike, not TLS specifically),
+/// appends a hint pointing at the possible causes.
 fn request_failed_msg(provider: &str, e: &reqwest::Error) -> String {
     request_failed_msg_from_parts(provider, e, e.is_connect())
 }
@@ -384,7 +386,10 @@ fn request_failed_msg_from_parts(
 ) -> String {
     let mut msg = format!("{provider} API request failed: {err}");
     if is_connect {
-        msg.push_str("\n  Hint: this may be caused by a corporate CA or proxy environment.");
+        msg.push_str(
+            "\n  Hint: could not connect — check your network/DNS, \
+             or a corporate proxy/CA if you're behind one.",
+        );
     }
     msg
 }
@@ -583,7 +588,8 @@ mod tests {
         assert_eq!(
             msg,
             "OpenAI API request failed: connection refused\n  \
-             Hint: this may be caused by a corporate CA or proxy environment."
+             Hint: could not connect — check your network/DNS, \
+             or a corporate proxy/CA if you're behind one."
         );
     }
 
@@ -609,7 +615,7 @@ mod tests {
         let err = client.get("http://127.0.0.1:1").send().await.unwrap_err();
         assert!(err.is_connect());
         let msg = request_failed_msg("Test", &err);
-        assert!(msg.contains("corporate CA or proxy"));
+        assert!(msg.contains("could not connect"));
     }
 
     #[tokio::test]

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -171,6 +171,7 @@ not a gap waiting to be fixed.
 | Child process logs env vars after `lkr exec` | LKR has no control over child behavior | Audit child programs; avoid untrusted commands |
 | Clipboard manager capturing copied keys | Third-party clipboard managers may persist history | 30s auto-clear mitigates; disable clipboard managers for sensitive use |
 | macOS deprecates Custom Keychain / CSSM format | Layer 2 (ACL) may stop working | Layer 1 (isolation) is independent; `lkr harden` serves as migration point; see Platform Dependency Risk |
+| Revoked-but-not-yet-expired TLS certificate on api.openai.com/api.anthropic.com | `lkr usage`'s TLS stack (`rustls`, since a dependency-hygiene update) does no OCSP/CRL revocation checking, unlike the previous `native-tls`/Secure Transport backend's best-effort checks | Low practical risk (both APIs use major CAs); accepted rustls-ecosystem tradeoff, not LKR-specific |
 
 ### Keychain ACL Investigation (v0.2.1 — updated v0.3.0)
 


### PR DESCRIPTION
## Summary

Root Cargo.toml's `reqwest` dependency wasn't disabling default features, so `Cargo.lock` pulled in `native-tls`/`hyper-tls`/`tokio-native-tls`/`openssl` alongside `rustls` even though the code only does plain HTTPS GETs. `Cargo.lock` had also been frozen since 2026-03-14, accumulating 5 outstanding RustSec advisories against `rustls-webpki`/`quinn-proto`, and `cargo audit` was about to go red on the CI schedule.

- Switched `reqwest` to `default-features = false, features = ["rustls-tls-native-roots", "json", "charset", "system-proxy"]` — drops native-tls/openssl/hyper-tls/tokio-native-tls entirely from the resolved build graph, keeps system trust store integration (`rustls-native-certs`), system proxy auto-detection, and response body charset decoding
- `cargo update -p rustls-webpki -p quinn-proto` clears all 5 advisories (also incidentally resolves an `rand` unsound warning as a transitive side effect)
- `usage` request-failure errors now include a hint for connection-level failures (network/DNS issues as well as corporate proxy/CA environments — not a diagnosis, just a pointer)
- `reqwest::Client` is now built once and cached (`OnceLock`) instead of per-fetch, since building one now reads the OS trust store
- Fixed 3 pre-existing `useless_borrows_in_formatting` clippy failures unrelated to this change (caught by a newer clippy version than CI last ran with) — bundled as a separate prep commit so CI's clippy job passes
- Corrected an initial CHANGELOG overclaim: this repo's TLS backend was already drawing trust from the OS store before this change (via `native-tls`/Secure Transport, reqwest's pre-v0.13 default when `default-features` isn't disabled) — this is a TLS backend swap (Secure Transport → rustls), not a change in which CAs are trusted. Documented the OCSP/CRL revocation-checking tradeoff (rustls does none by default, unlike Secure Transport's best-effort checks) in `docs/SECURITY.md`

Reviewed via Codex (2 rounds code review + adversarial test review, both converged clean) and 4-angle `/simplify` pass (reuse/simplification/efficiency/altitude) and an independent Security Review (GO, no Critical/Major).

Refs #18, #19

## Test plan

- [x] `cargo audit` exit 0, zero ignore entries
- [x] `cargo tree -i native-tls` / `-i hyper-tls` / `-i tokio-native-tls` / `-i openssl` all empty
- [x] `cargo tree` shows `rustls-native-certs` as the root CA source (not `webpki-roots`)
- [x] `cargo build --workspace`, `cargo test --workspace` (75 tests), `cargo clippy --workspace -- -D warnings`, `cargo fmt --all -- --check` all green
- [ ] Manual: real-key `lkr usage openai` / `lkr usage anthropic` succeed, including over `HTTPS_PROXY` — **not run by Claude** (no real Keychain access per this repo's `.claude/rules/security.md`); needs to be verified by @yottayoshida

🤖 Generated with [Claude Code](https://claude.com/claude-code)