### PR TITLE
docs: remove stale maintenance notice, state macOS-only scope for v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LLM Key Ring (`lkr`)
 
-> **Note:** This project is no longer actively maintained. It works as-is but no new features or fixes are planned.
+> **Status:** Actively developed toward v1.0 — see [Epic #61](https://github.com/yottayoshida/llm-key-ring/issues/61) for the roadmap and open issues.
 
 [![CI](https://github.com/yottayoshida/llm-key-ring/actions/workflows/ci.yml/badge.svg)](https://github.com/yottayoshida/llm-key-ring/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/lkr-cli.svg)](https://crates.io/crates/lkr-cli)
@@ -43,7 +43,7 @@ cd llm-key-ring
 cargo install --path crates/lkr-cli
 ```
 
-Requires macOS (uses native Keychain). Source build requires Rust 1.85+.
+Requires macOS (uses native Keychain) — see [*Why macOS-only?*](#why-macos-only) for the reason. Source build requires Rust 1.85+.
 
 > **Note**: After upgrading (`brew upgrade lkr` or `cargo install --force`), run `lkr harden`
 > to refresh Keychain ACL for the new binary.
@@ -253,9 +253,19 @@ All business logic lives in `lkr-core`. The CLI is a thin wrapper. v0.3.0 adds t
 - **`acl`**: Legacy ACL builder using `SecAccessCreate` + `SecTrustedApplicationCreateFromPath`
 - **`keychain_raw`**: Low-level item CRUD via `SecKeychainItemCreateFromContent` (with initial ACL)
 
-### Platform Support
+### Why macOS-only?
 
-Currently macOS only (uses native Keychain via `security-framework` / `security-framework-sys` direct FFI). The `KeyStore` trait abstraction is designed for future backend support (Linux `libsecret`, Windows Credential Manager).
+v1.0 is macOS-only by design, not by lack of effort. `lkr`'s actual value — the 3-layer
+defense (Custom Keychain isolation, Legacy ACL + cdhash binary integrity binding) — is
+built on macOS's CSSM Keychain internals via `security-framework` / `security-framework-sys`
+direct FFI. A Linux or Windows backend could store keys, but couldn't honor those specific
+guarantees; shipping one under the same guarantees would be a false promise. See
+[docs/SECURITY.md — Platform Dependency Risk](docs/SECURITY.md#platform-dependency-risk)
+for how this architecture is designed to survive changes *within* macOS itself.
+
+Want `lkr` on Linux or Windows anyway (with a reduced security model)? Add your use case to
+[the tracking issue](https://github.com/yottayoshida/llm-key-ring/issues/65) — it's not planned
+for v1.0, but demand shapes what comes after.
 
 ### Keychain Storage
 
@@ -364,8 +374,7 @@ remain readable via v0.2.x fallback until you manually remove them.
 | **v0.3.2** | **Operational Quality** | List N+1 fix, CLI module split, unsafe SAFETY docs, Homebrew tap |
 | **v0.3.3** | **Bug Fix** | `lkr migrate` circular error fix |
 | **v0.3.4** (current) | **Bug Fix** | `lkr harden` ACL fix after binary update ([#13](https://github.com/yottayoshida/llm-key-ring/issues/13)) |
-| v0.3.5 | Diagnostics | `lkr doctor` (Keychain health check) |
-| v0.4.0 | MCP Server | IDE integration for secure key access |
+| v1.0 | Verifiable S/A-tier OSS | See [Epic #61](https://github.com/yottayoshida/llm-key-ring/issues/61) for the current roadmap and open issues |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # LLM Key Ring (`lkr`)
 
-> **Status:** Actively developed toward v1.0 — see [Epic #61](https://github.com/yottayoshida/llm-key-ring/issues/61) for the roadmap and open issues.
+> **Status:** Working toward v1.0 — see [Epic #61](https://github.com/yottayoshida/llm-key-ring/issues/61) for the roadmap and current activity.
 
 [![CI](https://github.com/yottayoshida/llm-key-ring/actions/workflows/ci.yml/badge.svg)](https://github.com/yottayoshida/llm-key-ring/actions/workflows/ci.yml)
 [![crates.io](https://img.shields.io/crates/v/lkr-cli.svg)](https://crates.io/crates/lkr-cli)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -394,8 +394,7 @@ enabling kind-based access control without separate metadata storage.
 | **v0.3.2** | Operational quality: list N+1 fix, CLI module split, Homebrew tap |
 | **v0.3.3** | Bug fix: `lkr migrate` circular error |
 | **v0.3.4** (current) | Fix: `lkr harden` ACL chicken-and-egg — interactive get/set for cdhash mismatch recovery; `exists()` `-25293` fix |
-| v0.3.5 | Diagnostics: `lkr doctor` (search list pollution, ACL/cdhash integrity check) |
-| v0.4.0 | MCP server with scoped access tokens |
+| v1.0 | Verifiable S/A-tier OSS — see [Epic #61](https://github.com/yottayoshida/llm-key-ring/issues/61) for the current roadmap and open issues |
 
 ## Reporting Security Issues
 


### PR DESCRIPTION
## Summary

- README.md:3 declared the project "no longer actively maintained" — false since batch A (RustSec/TLS/dependency fixes, #62-#64) shipped. Replaced with a pointer to Epic #61 rather than an asserted "actively developed" claim, so activity status stays observable via a live tracker instead of a promise that can go stale again.
- README.md:258 claimed the KeyStore trait was "designed for future backend support (Linux libsecret, Windows Credential Manager)" — an over-promise contradicting the v1.0 macOS-only decision (2026-07-15). Replaced with a "Why macOS-only?" section explaining the 3-layer defense is macOS CSSM-specific, linking docs/SECURITY.md's Platform Dependency Risk and a new demand-signal tracking issue (#65).
- Both README.md and docs/SECURITY.md Roadmap tables listed stale "v0.3.5 Diagnostics"/"v0.4.0 MCP Server" next-steps that contradict the v1.0 Epic (MCP is out of v1.0 scope). Replaced both future rows with a single Epic #61 pointer.

Swept CHANGELOG.md and docs/SECURITY.md for other frozen/abandoned wording — the remaining "no longer"/"deprecat*" hits (CHANGELOG.md:72, SECURITY.md:43/127/208) are all technical behavior descriptions (macOS API deprecation, code-behavior fixes), not project-status claims, and are left untouched.

**Note**: crates.io still shows the old README (with the maintenance notice) on both the lkr-core and lkr-cli package pages until the next `cargo publish` — a physical limitation of the readme-points-to-a-file mechanism, not fixable from this repo. `crates/lkr-app/` (a Tauri GUI, not a workspace member) still exists in the repo but is tracked for removal separately (#58), so it's out of this sweep's scope.

Reviewed via Codex-proxy adversarial review (Codex MCP out of credits; fresh-subagent delegation): Ship verdict, 0 Critical/Major, 1 non-blocking style nit (left as-is, pre-existing ambiguity in SECURITY.md too). Independently re-verified: issue links resolve to real, matching issues; roadmap table historical rows untouched; anchor links match actual heading slugs; no cross-platform code exists in the codebase (grep confirmed) so the "couldn't honor those guarantees" framing isn't an overclaim.

Closes #46, #48

## Test plan

- [x] `cargo build/test/clippy/fmt --workspace` unaffected (docs-only, README not referenced from any `.rs`)
- [x] Grep sweep re-run post-edit: zero maintenance/cross-platform claims remain outside pre-verified false positives
- [x] Anchor links (`#why-macos-only`, `docs/SECURITY.md#platform-dependency-risk`) verified against actual heading text
- [x] Epic #61 and issue #65 confirmed to exist and match the stated framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)