### PR TITLE
ci: run cargo deny check on every PR, not just Cargo/deny.toml changes

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,11 +10,10 @@ on:
       - ".github/workflows/audit.yml"
   pull_request:
     branches: [main]
-    paths:
-      - "**/Cargo.toml"
-      - "Cargo.lock"
-      - "deny.toml"
-      - ".github/workflows/audit.yml"
+    # No paths filter here (unlike push, above): this is a required status
+    # check on main's branch protection, so it must run on every PR or
+    # PRs that don't touch these paths will never get a "cargo deny check"
+    # check-run and sit stuck on "Expected — waiting for status" forever.
   schedule:
     # Catches new advisories between pushes. GitHub disables scheduled
     # workflows after 60 days of repo inactivity — check this is still

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -10,10 +10,11 @@ on:
       - ".github/workflows/audit.yml"
   pull_request:
     branches: [main]
-    # No paths filter here (unlike push, above): this is a required status
-    # check on main's branch protection, so it must run on every PR or
-    # PRs that don't touch these paths will never get a "cargo deny check"
-    # check-run and sit stuck on "Expected — waiting for status" forever.
+    # No paths filter here (unlike push, above): this job is slated to
+    # become a required status check on main's branch protection (#47),
+    # so it must run on every PR — otherwise PRs that don't touch these
+    # paths would never get a "cargo deny check" check-run and would sit
+    # stuck on "Expected — waiting for status" forever once required.
   schedule:
     # Catches new advisories between pushes. GitHub disables scheduled
     # workflows after 60 days of repo inactivity — check this is still


### PR DESCRIPTION
## Summary

Removes the `pull_request` paths filter from `audit.yml` (`push` and `schedule` triggers keep it). This is a prerequisite for making "cargo deny check" a required status check on main's branch protection (#47): with the paths filter in place, a PR that doesn't touch Cargo.toml/Cargo.lock/deny.toml (e.g. a docs-only PR) would never get that check-run created, and GitHub would leave the PR permanently stuck on "Expected — waiting for status" if the check were required.

Cost: `cargo deny check` runs on every PR now instead of only dependency-touching ones (~25-30s added per PR, based on the 2 runs so far — this may need revisiting once there's more run history).

Reviewed via Codex-proxy adversarial review: Ship verdict, 0 Critical/Major. One Minor caught and fixed in a follow-up commit (comment tense — said "is a required check" before #47 landed; now "slated to become").

Refs #47

## Test plan

- [x] YAML parses correctly, `pull_request:` now has no `paths` key → fires on every PR per GitHub Actions semantics
- [x] `push` (4-path filter) and `schedule` (weekly cron) blocks confirmed byte-for-byte unchanged
- [ ] After merge: confirm a non-Cargo-touching PR (e.g. this repo's next docs PR) gets a `cargo deny check` check-run

🤖 Generated with [Claude Code](https://claude.com/claude-code)